### PR TITLE
Modify the text for @arialabel on examples/en/05_Image/03_Alpha_Mask

### DIFF
--- a/src/data/examples/en/05_Image/03_Alpha_Mask.js
+++ b/src/data/examples/en/05_Image/03_Alpha_Mask.js
@@ -1,6 +1,6 @@
 /*
  * @name Alpha Mask
- * @arialabel An astronaut on a planet as the background with a slightly transparent version of this image on top that moves with of the user’s mouse. Both have a light blue gradient on the right side.
+ * @arialabel An astronaut on a planet as the background with a slightly transparent version of this image on top that moves with the user’s mouse. Both have a light blue gradient on the right side.
  * @description Loads a "mask" for an image to specify the transparency in
  * different parts of the image. The two images are blended together using
  * the mask() method of p5.Image.

--- a/src/data/examples/en/05_Image/03_Alpha_Mask.js
+++ b/src/data/examples/en/05_Image/03_Alpha_Mask.js
@@ -1,6 +1,6 @@
 /*
  * @name Alpha Mask
- * @arialabel An astronaut on a planet as the background with a slightly transparent version of this image on top that moves with the horizontal direction of the user’s mouse. Both have a light blue gradient on the right side.
+ * @arialabel An astronaut on a planet as the background with a slightly transparent version of this image on top that moves with of the user’s mouse. Both have a light blue gradient on the right side.
  * @description Loads a "mask" for an image to specify the transparency in
  * different parts of the image. The two images are blended together using
  * the mask() method of p5.Image.


### PR DESCRIPTION
Fix: Modify the text for @arialabel to match the actual movement of the image
[https://p5js.org/examples/image-alpha-mask.html](https://p5js.org/examples/image-alpha-mask.html)

 Changes: 
 From

 ' * @arialabel An astronaut on a planet as the background with a slightly transparent version of this image on top that moves with the horizontal direction of the user’s mouse. Both have a light blue gradient on the right side.'
 
 to
 
' * @arialabel An astronaut on a planet as the background with a slightly transparent version of this image on top that moves with of the user’s mouse. Both have a light blue gradient on the right side.'
